### PR TITLE
Fix PHP opening tag in ada.php configuration file

### DIFF
--- a/config/ada.php
+++ b/config/ada.php
@@ -1,4 +1,4 @@
-    <?php
+<?php
 
     return [
         'client_token' => env('ADA_CLIENT_TOKEN'),


### PR DESCRIPTION
Extra space before php tag (this breaks a lot of things)